### PR TITLE
Change architecture type to i386-nlp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Change log
 -----------
 
+* Change architecture type to i386-nlp in the .coffee file in order to match the supervisor architecture type [Florin]
+
 # v2.0.0-beta12.rev1 - 2017-02-27
 
 * Bump resin-yocto-scripts to current HEAD [Andrei]

--- a/intel-quark.coffee
+++ b/intel-quark.coffee
@@ -12,7 +12,7 @@ module.exports =
 	slug: 'cybertan-ze250'
 	aliases: [ 'ZE250' ]
 	name: 'Cybertan ZE250'
-	arch: 'i386'
+	arch: 'i386-nlp'
 	state: 'preview'
 
 	stateInstructions:


### PR DESCRIPTION
We need to match the supervisor architecture type which is i386-nlp

Signed-off-by: Florin Sarbu <florin@resin.io>